### PR TITLE
COMP: Use vtkMRMLLabelMapVolumeNode

### DIFF
--- a/iGyne/iGyneWizard/iGyneFirstRegistrationStep.py
+++ b/iGyne/iGyneWizard/iGyneFirstRegistrationStep.py
@@ -1057,7 +1057,7 @@ class iGyneFirstRegistrationStep( iGyneStep ) :
     #
     #logFile = open('d:/pyLog.txt', 'w')
     #
-    if volumeNode.GetLabelMap() == 0:
+    if not volumeNode.IsA("vtkMRMLLabelMapVolumeNode"):
       print('Warning: input volume is not labelmap: \'' + volumeNode.GetName() + '\'')
     #  
     numberOfStructureVoxels = 0

--- a/iGyne/iGyneWizard/iGyneSecondRegistrationStep.py
+++ b/iGyne/iGyneWizard/iGyneSecondRegistrationStep.py
@@ -144,10 +144,8 @@ class iGyneSecondRegistrationStep( iGyneStep ) :
     # Select segmentation button (disabled)
     roiLabel = qt.QLabel( 'Select segmentation:' )
     self.__roiLabelSelector = slicer.qMRMLNodeComboBox()
-    self.__roiLabelSelector.nodeTypes = ( 'vtkMRMLScalarVolumeNode', '' )
-    self.__roiLabelSelector.addAttribute('vtkMRMLScalarVolumeNode','LabelMap','1')
+    self.__roiLabelSelector.nodeTypes = ( 'vtkMRMLLabelMapVolumeNode', '' )
     self.__roiLabelSelector.toolTip = "Choose the ROI segmentation"
-    self.__roiLabelSelector.nodeTypes = ['vtkMRMLScalarVolumeNode']
     self.__roiLabelSelector.addEnabled = 0
     self.__roiLabelSelector.setMRMLScene(slicer.mrmlScene)
     


### PR DESCRIPTION
A new class for labelmap nodes (vtkMRMLLabelmapNode) was introduced into the Slicer core
that replaces the old method of storing segmentation in a vtkMRMLScalarVolumeNode with
a custom “labelmap” attribute set to "1".
See details here:
http://www.slicer.org/slicerWiki/index.php/Documentation/Labs/Segmentations#vtkMRMLLabelMapVolumeNode_integration

This change in the Slicer core requires modification of your extension. See the suggested change in this commit.
