### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(EXTENSION_CONTRIBUTORS "Guillaume Pernelle,  Alireza Mehrtash, Lauren Barber
 set(EXTENSION_DESCRIPTION "iGyne: It is an open source software for MR-Guided Interstitial Gynecologic Brachytherapy. It enables on-time processing of the intra-operative MRI data via a DICOM connection to the scanner followed by a multi-stage registration of CAD models of the template and the obturator to the patient images. This allows the virtual placement of interstitial needles during the intervention, as well as the detection/labeling of needles in MR images")
 
 set(EXTENSION_ICONURL "https://raw.github.com/gpernelle/iGyne/master/iGyne.png")
-set(EXTENSION_SCREENSHOTURLS "https://raw.github.com/gpernelle/iGyne/master/LabelingResult.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/gpernelle/iGyne/master/LabelingResults.png")
 
 #-----------------------------------------------------------------------------
 # Extension dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.